### PR TITLE
Update README with documentation for removing imported models

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Available models (↑/↓ to navigate, SPACE to select, ENTER to confirm, Ctrl+C
 ```
 Navigate <up> and <down>, hit `<space>` to select models to import and then hit `<enter>` to confirm.
 
+### Removing imported models
+
+If an already imported model is selected, it will be removed from the list of models registered with llm-mlx.
+
 ## Using models from Python
 
 If you have registered models with the `llm download-model` command you can use in Python like this:


### PR DESCRIPTION
Documentation updated to explain the way to remove already imported modules. Probably a rename in manage-models would be better. @simonw you are the boss here.

This helps with #9  