### PR TITLE
Add tool use MVP to MLX models

### DIFF
--- a/llm_mlx.py
+++ b/llm_mlx.py
@@ -206,6 +206,8 @@ class MlxModel(llm.Model):
         if self._tool_format is None:
             # Detect tool call format from tokenizer's chat template
             self._tool_format = self._detect_tool_format(self._tokenizer)
+            if DEBUG:
+                print(f"Detected tool format: {self._tool_format}")
 
         if DEBUG:
             print("Template is", self._tokenizer.chat_template)
@@ -477,8 +479,8 @@ class MlxModel(llm.Model):
             "finish_reason": chunk.finish_reason,
         }
         
-        # Parse tool calls if tools are available and we don't have results yet
-        if prompt.tools and not prompt.tool_results:
+        # Parse tool calls if tools are available
+        if prompt.tools:
             tool_calls = self._parse_tool_calls(generated_text, prompt.tools, self._tool_format)
             if tool_calls:
                 for tool_call in tool_calls:

--- a/llm_mlx.py
+++ b/llm_mlx.py
@@ -294,8 +294,8 @@ class MlxModel(llm.Model):
             "llama3x": [
                 # Llama 3.x simple format: {"name": "func", "parameters": {...}}
                 (r'\{\s*"name"\s*:\s*"([^"]+)"\s*,\s*"parameters"\s*:\s*(\{[^}]*\})\s*\}', 'llama3x'),
-                # # Also handle "arguments" variant
-                # (r'\{\s*"name"\s*:\s*"([^"]+)"\s*,\s*"arguments"\s*:\s*(\{[^}]*\})\s*\}', 'llama3x_args'),
+                # Also handle "arguments" variant
+                (r'\{\s*"name"\s*:\s*"([^"]+)"\s*,\s*"arguments"\s*:\s*(\{[^}]*\})\s*\}', 'llama3x_args'),
             ],
             "hermes": [
                 # Hermes XML format: <tool_call>{"name": "func", "arguments": {...}}</tool_call>

--- a/llm_mlx.py
+++ b/llm_mlx.py
@@ -240,12 +240,18 @@ class MlxModel(llm.Model):
         # Add tool results from current prompt if any
         if prompt.tool_results:
             for tool_result in prompt.tool_results:
-                messages.append({
+                message ={
                     "role": "tool",  # Template should convert to ipython for llama3.x
                     "name": tool_result.name,
                     "tool_call_id": tool_result.tool_call_id,
                     "content": json.loads(tool_result.output),
-                })
+                }
+                # Qwen 3 format requires JSON string in content
+                if self._tool_format == "qwen3":
+                    message["content"] = json.dumps(tool_result.output)
+                messages.append(message)
+                if DEBUG:
+                    print("Tool result added:", tool_result.name, tool_result.output)  # Debug output
         
         # Add current user message (unless we're just adding tool results)
         if not prompt.tool_results:
@@ -265,6 +271,8 @@ class MlxModel(llm.Model):
             # Analyze template content for format markers (like llama.cpp does)
             if "<｜tool▁calls▁begin｜>" in template_str:
                 return "deepseek_r1"
+            elif "qwen" in self.model_path.lower():
+                return "qwen3"  # Qwen often uses <tool_call> format
             elif "<tool_call>" in template_str:
                 return "hermes"
             elif "<|start_header_id|>ipython<|end_header_id|>" in template_str:
@@ -278,8 +286,6 @@ class MlxModel(llm.Model):
             # Additional patterns for better detection
             elif "llama" in self.model_path.lower() and ("3.2" in self.model_path or "3.1" in self.model_path):
                 return "llama3x"
-            elif "qwen" in self.model_path.lower():
-                return "hermes"  # Qwen often uses <tool_call> format
             elif "mistral" in self.model_path.lower() and "nemo" in self.model_path.lower():
                 return "mistral_nemo"
             else:
@@ -296,6 +302,10 @@ class MlxModel(llm.Model):
                 (r'\{\s*"name"\s*:\s*"([^"]+)"\s*,\s*"parameters"\s*:\s*(\{[^}]*\})\s*\}', 'llama3x'),
                 # Also handle "arguments" variant
                 (r'\{\s*"name"\s*:\s*"([^"]+)"\s*,\s*"arguments"\s*:\s*(\{[^}]*\})\s*\}', 'llama3x_args'),
+            ],
+            "qwen3": [
+                # Qwen 3 format: <tool_call>{"name": "func", "arguments": {...}}</tool_call>
+                (r'<tool_call>\s*\{\s*"name"\s*:\s*"([^"]+)"\s*,\s*"arguments"\s*:\s*(\{[^}]*\})\s*\}\s*</tool_call>', 'qwen3'),
             ],
             "hermes": [
                 # Hermes XML format: <tool_call>{"name": "func", "arguments": {...}}</tool_call>


### PR DESCRIPTION
This is an MVP for tool usage support for MLX-based models. It uses `apply_chat_template` to add tool definitions to the chat template (assuming the model already has a tool call template). The plugin tries to detect the tool format. And if it cannot identify it, it adds a generic tool calling prompt of its own to the system prompt (this is admittedly a bit janky and can be removed if deemed too unpolished). 

Tool parsing is done based on the detected tool format and a set of fixed rules.
Tool results are added to the conversation using the template.

It also works with thinking models like qwen3. Multiple tool calls in a single request is supported.

This has been tested so far with the following models:

* mxmcc/Llama-xLAM-2-8b-fc-r-mlx-8Bit
* mlx-community/Llama-3.2-3B-Instruct-4bit
* mlx-community/Qwen3-8B-4bit
* mlx-community/gemma-3-12b-it-4bit-DWQ

Some models struggle if asked for more than one tool call at once. I have had good results with the Qwen3-8b model listed above.