### PR TITLE
Add support for GPT-OSS Harmony-style chat templates

### DIFF
--- a/llm_mlx.py
+++ b/llm_mlx.py
@@ -150,6 +150,66 @@ def register_models(register):
         register(MlxModel(model_path), aliases=aliases)
 
 
+def _tokenizer_uses_harmony(tokenizer):
+    """
+    Detect if this tokenizer uses a GPT-OSS Harmony-style chat template.
+
+    Harmony templates use <|channel|> tags and expect 'thinking' fields
+    for analysis content.
+    """
+    try:
+        template = tokenizer.chat_template
+        if template and isinstance(template, str):
+            has_channel = "<|channel|>" in template
+            has_thinking = "thinking" in template
+            # Check for Harmony-specific markers
+            return has_channel and has_thinking
+        return False
+    except (AttributeError, TypeError) as e:
+        return False
+
+
+def _split_harmony_message(text):
+    """
+    Parse a Harmony-formatted response into analysis and final sections.
+
+    Expected format:
+        <|channel|>analysis<|message|>
+        ... thinking content ...
+        <|end|>
+        <|channel|>final<|message|>
+        ... final answer ...
+        <|end|>
+
+    Returns a tuple of (analysis_text, final_text).
+    The channel tags are stripped - only the content between <|message|> and <|end|> is kept.
+    Handles incomplete responses where the final <|end|> tag might be missing.
+    """
+    import re
+
+    analysis_text = ""
+    final_text = ""
+
+    # Pattern to match analysis section (content between <|message|> and <|end|>)
+    analysis_pattern = r'<\|channel\|>analysis\s*<\|message\|>(.*?)<\|end\|>'
+    analysis_match = re.search(analysis_pattern, text, re.DOTALL)
+    if analysis_match:
+        analysis_text = analysis_match.group(1).strip()
+
+    # Pattern to match final section (content between <|message|> and optional <|end|>)
+    # Handle both complete responses (with <|end|>) and incomplete ones (without)
+    final_pattern = r'<\|channel\|>final\s*<\|message\|>(.*?)(?:<\|end\|>|$)'
+    final_match = re.search(final_pattern, text, re.DOTALL)
+    if final_match:
+        final_text = final_match.group(1).strip()
+
+    # If no sections found, assume the entire text is the final answer
+    if not analysis_text and not final_text:
+        final_text = text
+
+    return analysis_text, final_text
+
+
 class MlxModel(llm.Model):
     can_stream = True
 
@@ -210,6 +270,9 @@ class MlxModel(llm.Model):
 
         model, tokenizer = self._load()
 
+        # Check if this model uses Harmony template
+        is_harmony = _tokenizer_uses_harmony(tokenizer)
+
         messages = []
         current_system = None
         if conversation is not None:
@@ -225,10 +288,27 @@ class MlxModel(llm.Model):
                 messages.append(
                     {"role": "user", "content": prev_response.prompt.prompt}
                 )
-                messages.append({"role": "assistant", "content": prev_response.text()})
+
+                # Get the full assistant response text
+                assistant_text = prev_response.text()
+
+                if is_harmony:
+                    # Parse the Harmony response to extract analysis and final sections
+                    analysis, final = _split_harmony_message(assistant_text)
+
+                    # Build message with thinking field for analysis
+                    assistant_msg = {"role": "assistant", "content": final}
+                    if analysis:
+                        assistant_msg["thinking"] = analysis
+                    messages.append(assistant_msg)
+                else:
+                    # Non-Harmony models: use the text as-is
+                    messages.append({"role": "assistant", "content": assistant_text})
+
         if prompt.system and prompt.system != current_system:
             messages.append({"role": "system", "content": prompt.system})
         messages.append({"role": "user", "content": prompt.prompt})
+
         chat_prompt = tokenizer.apply_chat_template(
             messages, add_generation_prompt=True
         )

--- a/tests/test_mlx.py
+++ b/tests/test_mlx.py
@@ -27,3 +27,46 @@ def test_model_options():
     assert options.top_p == 0.9
     assert options.min_p == 0.1
     assert response.json()["finish_reason"] == "length"
+
+
+def test_harmony_detection():
+    """Test that Harmony template detection works correctly."""
+
+    # Mock tokenizer with Harmony template
+    class MockHarmonyTokenizer:
+        chat_template = """
+        {% if message.thinking %}
+        <|channel|>analysis<|message|>{{ message.thinking }}<|end|>
+        {% endif %}
+        <|channel|>final<|message|>{{ message.content }}<|end|>
+        """
+
+    # Mock tokenizer without Harmony template
+    class MockNormalTokenizer:
+        chat_template = "{{ message.content }}"
+
+    # Mock tokenizer with no template
+    class MockNoTemplate:
+        pass
+
+    assert llm_mlx._tokenizer_uses_harmony(MockHarmonyTokenizer()) is True
+    assert llm_mlx._tokenizer_uses_harmony(MockNormalTokenizer()) is False
+    assert llm_mlx._tokenizer_uses_harmony(MockNoTemplate()) is False
+
+
+def test_split_harmony_message():
+    """Test that Harmony message splitting works correctly."""
+
+    harmony_text = """<|channel|>analysis<|message|>
+Let me think about this problem step by step.
+First, I need to understand what the user is asking.
+<|end|>
+<|channel|>final<|message|>
+Here is my final answer to your question.
+<|end|>"""
+
+    analysis, final = llm_mlx._split_harmony_message(harmony_text)
+    assert "Let me think about this problem step by step" in analysis
+    assert "Here is my final answer" in final
+    assert "<|channel|>" not in analysis
+    assert "<|channel|>" not in final


### PR DESCRIPTION
Harmony-based models (such as GPT-OSS variants) use a structured two-channel chat format: an internal **analysis** segment and the user-visible **final** answer, each wrapped in `<|channel|>` tags. When the Hugging Face Harmony chat template processes history, it requires:

- the **final** portion in `content`
- the **analysis** portion in a separate `thinking` field
- **no raw `<|channel|>` tags** inside either field

Before this PR, `llm-mlx` stored the entire raw model output (including both channels and tags) as the assistant message. On subsequent turns, when the history was passed back to `apply_chat_template()`, GPT-OSS models would raise:

> jinja2.exceptions.TemplateError: You have passed a message containing <|channel|> tags in the content field...

This PR detects Harmony chat templates and:

- parses the model’s response into analysis + final segments
- replays only the final text in `content`
- stores analysis in `thinking` (not shown to the user)
- removes all `<|channel|>` markers from history
- leaves non-Harmony models and streaming behavior unchanged

This enables correct multi-turn chat with GPT-OSS / Harmony models using `llm chat`.

A similar upstream change was proposed in mlx-lm (see https://github.com/ml-explore/mlx-lm/issues/365), but maintainers stated that the application layer is responsible for providing well-formed chat messages — so I think that means this behavior should be implemented here instead.
